### PR TITLE
Implement dynamic port launcher

### DIFF
--- a/New_API/Run_all_main.py
+++ b/New_API/Run_all_main.py
@@ -1,18 +1,31 @@
 import configparser
 import json
 from time import sleep
-import os
-from subprocess import Popen, CREATE_NEW_CONSOLE
+from subprocess import Popen
+import sys
+from pathlib import Path
 
 configDefault = configparser.ConfigParser()
-configDefault.read(['config.ini'])
+configDefault.read(["config.ini"])
 patch = configDefault.get("Config", "patch")
 folder_list = json.loads(configDefault.get("Config", "folder_list"))
 
+base_port = 8080
+
 if __name__ == "__main__":
-    for folder in folder_list:
-        print(patch + folder + "/main.py")
-        os.chdir(patch + folder)
-        Popen(["python", patch + folder + "/main.py"], creationflags=CREATE_NEW_CONSOLE)
-        #Popen(["python", patch + folder + "/main.py"])
+    for index, folder in enumerate(folder_list):
+        folder_path = Path(patch) / folder
+        port = base_port + index
+
+        config_path = folder_path / "config.ini"
+        config = configparser.ConfigParser()
+        config.read(config_path)
+        if not config.has_section("Config"):
+            config.add_section("Config")
+        config.set("Config", "port", str(port))
+        with open(config_path, "w") as f:
+            config.write(f)
+
+        print(folder_path / "main.py")
+        Popen([sys.executable, str(folder_path / "main.py")])
         sleep(0.5)


### PR DESCRIPTION
## Summary
- support dynamic port allocation in `Run_all_main.py`
- use `Path` for path handling and update each API's config
- launch each API process using the same Python executable

## Testing
- `python -m py_compile New_API/Run_all_main.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b160ecf8832b8551d96dd461d419