### PR TITLE
Assign unique ports for API launch

### DIFF
--- a/New_API/Run_all_main.py
+++ b/New_API/Run_all_main.py
@@ -12,9 +12,26 @@ config_default.read([CONFIG_PATH])
 patch = Path(config_default.get("Config", "patch"))
 folder_list = json.loads(config_default.get("Config", "folder_list"))
 
+# Base port used when calculating per-API ports
+base_port = 8080
+
 if __name__ == "__main__":
-    for folder in folder_list:
+    for index, folder in enumerate(folder_list):
+        # Compute a unique port number for this API
+        port = base_port + index
+
+        # Update the folder's config.ini with the computed port
+        config_path = patch / folder / "config.ini"
+        cfg = configparser.ConfigParser()
+        cfg.read([config_path])
+        if not cfg.has_section("Config"):
+            cfg.add_section("Config")
+        cfg.set("Config", "port", str(port))
+        with open(config_path, "w") as config_file:
+            cfg.write(config_file)
+
+        # Launch the API using the current Python executable
         main_path = patch / folder / "main.py"
-        print(main_path)
+        print(f"Starting {main_path} on port {port}")
         subprocess.Popen([sys.executable, str(main_path)])
         sleep(0.5)


### PR DESCRIPTION
## Summary
- start APIs with sys.executable
- assign incremental ports starting from 8080
- update each API's config.ini before start

## Testing
- `python -m py_compile New_API/Run_all_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b5958500832bb1312a4f698fbe03