### PR TITLE
Drop Windows-only launcher details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Install Python dependencies:
 pip install -r requirements.txt
 ```
 
-Run the launcher script to start update jobs and all APIs defined in `New_API/config.ini`:
+Run the launcher script to start update jobs and all APIs defined in `New_API/config.ini`.
+The same command works on Windows, macOS, and Linux:
 
 ```bash
 python New_API/launcher.py
 ```
-This cross-platform command replaces the old Windows `.bat` launchers.
+This command replaces the old Windows `.bat` launchers and is fully cross-platform.
 
 Each API folder contains its own `config.ini` specifying the port and other configuration. `Run_all_main.py` reads `New_API/config.ini` to determine which folders to start.
 


### PR DESCRIPTION
## Summary
- note the cross-platform Python launcher in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b5972328832b87b7de8a441c0080