### PR TITLE
Allow configurable patch path

### DIFF
--- a/New_API/Run_all_main.py
+++ b/New_API/Run_all_main.py
@@ -1,5 +1,6 @@
 import configparser
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,7 +10,7 @@ CONFIG_PATH = Path(__file__).resolve().parent / "config.ini"
 
 config_default = configparser.ConfigParser()
 config_default.read([CONFIG_PATH])
-patch = Path(config_default.get("Config", "patch"))
+patch = Path(os.getenv("PATCH_DIR", config_default.get("Config", "patch")))
 folder_list = json.loads(config_default.get("Config", "folder_list"))
 
 if __name__ == "__main__":

--- a/New_API/Update_BonusTime.py
+++ b/New_API/Update_BonusTime.py
@@ -1,5 +1,6 @@
 import configparser
 import json
+import os
 import random
 import sys
 from datetime import datetime
@@ -28487,7 +28488,7 @@ def BONUSTIME_YGR(api_folder):
 
 configDefault = configparser.ConfigParser()
 configDefault.read(['config.ini'])
-patch = configDefault.get("Config", "patch")
+patch = os.getenv("PATCH_DIR", configDefault.get("Config", "patch"))
 folder_list = json.loads(configDefault.get("Config", "folder_list"))
 
 for folder in folder_list:

--- a/New_API/Update_BonusTime_Baccarat.py
+++ b/New_API/Update_BonusTime_Baccarat.py
@@ -1,5 +1,6 @@
 import configparser
 import json
+import os
 import random
 import sys
 from datetime import datetime
@@ -4915,7 +4916,7 @@ def BONUSTIME_MT(api_folder):
 
 configDefault = configparser.ConfigParser()
 configDefault.read(['config.ini'])
-patch = configDefault.get("Config", "patch")
+patch = os.getenv("PATCH_DIR", configDefault.get("Config", "patch"))
 folder_list = json.loads(configDefault.get("Config", "folder_list"))
 
 for folder in folder_list:

--- a/New_API/config.ini
+++ b/New_API/config.ini
@@ -1,5 +1,5 @@
 [Config]
-patch = C:/Users/Administrator/Desktop/
+patch = ./
 folder_list:
  [
    "API_Xbotline",

--- a/README.md
+++ b/README.md
@@ -28,4 +28,8 @@ docker build -t ppp-app .
 docker run --rm ppp-app
 ```
 
-Make sure the `patch` path in `New_API/config.ini` matches the location of the API folders inside the container (usually `/app/`).
+`New_API/config.ini` contains a `patch` option pointing to the directory that
+holds the `API_*` folders. By default it uses a relative path (`./`). You can
+override this location by setting the environment variable `PATCH_DIR` when
+running the scripts. When running in Docker the project is copied to `/app`, so
+start the container with `PATCH_DIR=/app` if you do not run from that directory.


### PR DESCRIPTION
## Summary
- make `patch` in `New_API/config.ini` relative
- allow `PATCH_DIR` env var to override the configured path
- document the new configuration options in the README

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6844b5980c88832bb27afbb2b2710a9e