### PR TITLE
Ensure Run_all_main uses cwd for API folders

### DIFF
--- a/New_API/Run_all_main.py
+++ b/New_API/Run_all_main.py
@@ -21,8 +21,9 @@ if __name__ == "__main__":
         # Compute a unique port number for this API
         port = base_port + index
 
+        folder_path = (patch / folder).resolve()
         # Update the folder's config.ini with the computed port
-        config_path = patch / folder / "config.ini"
+        config_path = folder_path / "config.ini"
         cfg = configparser.ConfigParser()
         cfg.read([config_path])
         if not cfg.has_section("Config"):
@@ -32,7 +33,7 @@ if __name__ == "__main__":
             cfg.write(config_file)
 
         # Launch the API using the current Python executable
-        main_path = patch / folder / "main.py"
+        main_path = folder_path / "main.py"
         print(f"Starting {main_path} on port {port}")
-        subprocess.Popen([sys.executable, str(main_path)])
+        subprocess.Popen([sys.executable, str(main_path)], cwd=folder_path)
         sleep(0.5)


### PR DESCRIPTION
## Summary
- run each API from its own folder so `config.ini` is read properly

## Testing
- `python -m py_compile New_API/Run_all_main.py`
- `python New_API/Run_all_main.py` *(fails: ImportError: cannot import name 'ShowLoadingAnimationRequest' from 'linebot.v3.messaging.models')*

------
https://chatgpt.com/codex/tasks/task_e_6844b86315a4832bb876b96383b67f7f