### PR TITLE
Fix launcher cwd

### DIFF
--- a/New_API/launcher.py
+++ b/New_API/launcher.py
@@ -6,7 +6,10 @@ API_DIR = Path(__file__).resolve().parent
 
 
 def run_script(name: str) -> None:
-    subprocess.Popen([sys.executable, str(API_DIR / name)])
+    subprocess.Popen(
+        [sys.executable, str(API_DIR / name)],
+        cwd=API_DIR  # ensure config.ini is found
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `launcher.py` launches scripts from `New_API` folder so they find `config.ini`
- keep each API started from its own folder in `Run_all_main.py`

## Testing
- `python -m py_compile New_API/launcher.py New_API/Run_all_main.py`
- `PATCH_DIR=.. python New_API/launcher.py` *(fails: KeyError 'Config', but no missing-config errors)*

------
https://chatgpt.com/codex/tasks/task_e_68458743cfa0832ba5800e19be713206