### PR TITLE
Skip missing folders when launching APIs

### DIFF
--- a/New_API/Run_all_main.py
+++ b/New_API/Run_all_main.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 from time import sleep
+import logging
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.ini"
 
@@ -12,6 +13,8 @@ config_default = configparser.ConfigParser()
 config_default.read([CONFIG_PATH])
 patch = Path(os.getenv("PATCH_DIR", config_default.get("Config", "patch")))
 folder_list = json.loads(config_default.get("Config", "folder_list"))
+
+logging.basicConfig(level=logging.INFO)
 
 # Base port used when calculating per-API ports
 base_port = 8080
@@ -22,6 +25,9 @@ if __name__ == "__main__":
         port = base_port + index
 
         folder_path = (patch / folder).resolve()
+        if not folder_path.is_dir():
+            logging.warning("Folder %s does not exist, skipping", folder_path)
+            continue
         # Update the folder's config.ini with the computed port
         config_path = folder_path / "config.ini"
         cfg = configparser.ConfigParser()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This command replaces the old Windows `.bat` launchers and is fully cross-platfo
 
 Each API folder contains its own `config.ini` specifying the port and other configuration. `Run_all_main.py` reads `New_API/config.ini` to determine which folders to start.
 
+`folder_list` should include only folders that are present under the patch directory; missing folders will be skipped with a warning.
+
 ## Docker
 
 Build and run using Docker:


### PR DESCRIPTION
## Summary
- skip nonexistent API folders in `Run_all_main.py`
- document `folder_list` requirements in README

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6845881b3c78832b80e312721c146231