### PR TITLE
Fix LINE SDK dependency for loading animation

### DIFF
--- a/API_Xbotline/requirements.txt
+++ b/API_Xbotline/requirements.txt
@@ -1,5 +1,5 @@
 aenum==3.1.15
-aiohttp==3.9.0
+aiohttp==3.9.5
 aiosignal==1.3.1
 annotated-types==0.6.0
 attrs==23.1.0
@@ -15,7 +15,7 @@ future==0.18.3
 idna==3.6
 itsdangerous==2.1.2
 Jinja2==3.1.2
-line-bot-sdk==3.5.1
+line-bot-sdk==3.11.0
 MarkupSafe==2.1.3
 multidict==6.0.4
 pydantic==2.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aenum==3.1.15
-aiohttp==3.9.0
+aiohttp==3.9.5
 aiosignal==1.3.1
 annotated-types==0.6.0
 attrs==23.1.0
@@ -15,7 +15,7 @@ future==0.18.3
 idna==3.6
 itsdangerous==2.1.2
 Jinja2==3.1.2
-line-bot-sdk==3.5.1
+line-bot-sdk==3.11.0
 MarkupSafe==2.1.3
 multidict==6.0.4
 pydantic==2.5.2


### PR DESCRIPTION
## Summary
- bump line-bot-sdk to 3.11.0 (earliest version with `ShowLoadingAnimationRequest`)
- sync API_Xbotline requirements
- align aiohttp version required by the SDK

## Testing
- `pip install -r requirements.txt`
- `python API_Xbotline/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684588cc17a0832b95ed2f92c881f405