### PR TITLE
Remove sys.exit calls in bonus update scripts

### DIFF
--- a/New_API/Update_BonusTime.py
+++ b/New_API/Update_BonusTime.py
@@ -28577,9 +28577,8 @@ for folder in folder_list:
       #BONUSTIME_WR(patch + folder)
       #BONUSTIME_MT(patch + folder)
     except Exception as e:
-        print(e)
-        print(folder_str)
-    sys.exit(0)
+        logging.exception("Error processing %s", folder_str)
+        continue
       
     if debug:
         print("\n")

--- a/New_API/Update_BonusTime_Baccarat.py
+++ b/New_API/Update_BonusTime_Baccarat.py
@@ -4956,9 +4956,8 @@ for folder in folder_list:
       BONUSTIME_WR(folder_str)
       BONUSTIME_MT(folder_str)
     except Exception as e:
-        print(e)
-        print(folder_str)
-    sys.exit(0)
+        logging.exception("Error processing %s", folder_str)
+        continue
     if debug:
         print("\n")
     time.sleep(0.4)


### PR DESCRIPTION
## Summary
- remove premature `sys.exit(0)` calls when processing bonus time updates
- log exceptions and continue looping over folders

## Testing
- `python -m py_compile New_API/Update_BonusTime.py New_API/Update_BonusTime_Baccarat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459761ec84832b84d98c0e5194ba59