### PR TITLE
Fix startup in Run_all_main

### DIFF
--- a/API_Xbotline/flex_message/main.py
+++ b/API_Xbotline/flex_message/main.py
@@ -304,5 +304,5 @@ def handle_message(event: MessageEvent):
 
 if __name__ == "__main__":
     register_flex_command()
-    app.run("0.0.0.0", config['Config']['port'], debug=True)
+    app.run("0.0.0.0", config['Config']['port'], debug=True, use_reloader=False)
 

--- a/API_Xbotline/main.py
+++ b/API_Xbotline/main.py
@@ -319,5 +319,5 @@ def handle_message(event: MessageEvent):
 
 if __name__ == "__main__":
     register_flex_command()
-    app.run("0.0.0.0", config['Config']['port'], debug=True)
+    app.run("0.0.0.0", config['Config']['port'], debug=True, use_reloader=False)
 


### PR DESCRIPTION
## Summary
- fix `app.run` usage in API_Xbotline scripts

## Testing
- `python -m py_compile API_Xbotline/main.py API_Xbotline/flex_message/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68459853ff58832ba0088ad775485a3e