### PR TITLE
Add healthcheck endpoint to API_Xbotline

### DIFF
--- a/API_Xbotline/main.py
+++ b/API_Xbotline/main.py
@@ -314,8 +314,14 @@ def handle_message(event: MessageEvent):
                     elif cmd =="/HANOIVIPLOTTOS":
                         reply_flex_message(event, line_bot_api, f"{c.replace('/', '')}.json","ขอให้ลูกค้าทุกท่านรวยๆ เฮงๆนะคะ")
                         return 0                                   
+
                     reply_flex_message(event, line_bot_api, f"{c.replace('/', '')}.json",cmd)
                     return
+
+
+@app.get("/healthcheck")
+def healthcheck():
+    return "OK", 200
 
 if __name__ == "__main__":
     register_flex_command()

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ holds the `API_*` folders. By default it uses a relative path (`./`). You can
 override this location by setting the environment variable `PATCH_DIR` when
 running the scripts. When running in Docker the project is copied to `/app`, so
 start the container with `PATCH_DIR=/app` if you do not run from that directory.
+
+## Healthcheck
+
+Each API exposes a `/healthcheck` endpoint that simply returns `"OK"`.


### PR DESCRIPTION
## Summary
- add `/healthcheck` endpoint to API_Xbotline
- document healthcheck endpoint in README

## Testing
- `python -m py_compile API_Xbotline/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cd2f97e8832ba8a16d5c7572d6f2